### PR TITLE
Add feed interactions

### DIFF
--- a/backend/controllers/feedController.js
+++ b/backend/controllers/feedController.js
@@ -1,4 +1,6 @@
 const Feed = require('../models/Feed');
+const FeedLike = require('../models/FeedLike');
+const FeedFav = require('../models/FeedFav');
 
 // GET /api/feed?page=1&perPage=10
 exports.getFeed = async (req, res) => {
@@ -33,5 +35,77 @@ exports.createFeed = async (req, res) => {
   } catch (err) {
     console.error("ERROR EN POST FEED:", err);
     res.status(500).json({ msg: 'Error al crear publicación.' });
+  }
+};
+
+// POST /api/feed/:id/like
+exports.likePost = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { username } = req.body;
+    if (!username) return res.status(400).json({ msg: 'Falta username.' });
+    await FeedLike.addLike({ feed_id: id, username });
+    res.json({ msg: 'Like registrado' });
+  } catch (err) {
+    res.status(500).json({ msg: 'Error al registrar like.' });
+  }
+};
+
+// GET /api/feed/:id/likes
+exports.getLikes = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const likes = await FeedLike.getLikesByFeed(id);
+    res.json(likes);
+  } catch (err) {
+    res.status(500).json({ msg: 'Error al obtener likes.' });
+  }
+};
+
+// POST /api/feed/:id/fav
+exports.favPost = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { username } = req.body;
+    if (!username) return res.status(400).json({ msg: 'Falta username.' });
+    await FeedFav.addFav({ feed_id: id, username });
+    res.json({ msg: 'Favorito agregado' });
+  } catch (err) {
+    res.status(500).json({ msg: 'Error al agregar favorito.' });
+  }
+};
+
+// GET /api/feed/:id/favs
+exports.getFavs = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const favs = await FeedFav.getFavsByFeed(id);
+    res.json(favs);
+  } catch (err) {
+    res.status(500).json({ msg: 'Error al obtener favoritos.' });
+  }
+};
+
+// POST /api/feed/:id/edit
+exports.editPost = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { mensaje } = req.body;
+    if (!mensaje) return res.status(400).json({ msg: 'Mensaje vacío.' });
+    await Feed.updateFeed(id, mensaje);
+    res.json({ msg: 'Post actualizado' });
+  } catch (err) {
+    res.status(500).json({ msg: 'Error al actualizar publicación.' });
+  }
+};
+
+// DELETE /api/feed/:id
+exports.deletePost = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await Feed.deleteFeed(id);
+    res.json({ msg: 'Post eliminado' });
+  } catch (err) {
+    res.status(500).json({ msg: 'Error al eliminar publicación.' });
   }
 };

--- a/backend/models/Feed.js
+++ b/backend/models/Feed.js
@@ -25,8 +25,18 @@ async function addFeed({ username, avatar, mensaje, tiempo }) {
   return result.insertId;
 }
 
+async function updateFeed(id, mensaje) {
+  await pool.query('UPDATE feeds SET mensaje = ? WHERE id = ?', [mensaje, id]);
+}
+
+async function deleteFeed(id) {
+  await pool.query('DELETE FROM feeds WHERE id = ?', [id]);
+}
+
 module.exports = {
   getFeedsPaginated,
   getAllFeeds,
   addFeed,
+  updateFeed,
+  deleteFeed,
 };

--- a/backend/models/FeedFav.js
+++ b/backend/models/FeedFav.js
@@ -1,0 +1,22 @@
+// models/FeedFav.js
+const pool = require('../config/db');
+
+async function addFav({ feed_id, username }) {
+  await pool.query(
+    'INSERT INTO feed_favs (feed_id, username) VALUES (?, ?)',
+    [feed_id, username]
+  );
+}
+
+async function getFavsByFeed(feedId) {
+  const [rows] = await pool.query(
+    'SELECT * FROM feed_favs WHERE feed_id = ? ORDER BY id ASC',
+    [feedId]
+  );
+  return rows;
+}
+
+module.exports = {
+  addFav,
+  getFavsByFeed,
+};

--- a/backend/models/FeedLike.js
+++ b/backend/models/FeedLike.js
@@ -1,0 +1,22 @@
+// models/FeedLike.js
+const pool = require('../config/db');
+
+async function addLike({ feed_id, username }) {
+  await pool.query(
+    'INSERT INTO feed_likes (feed_id, username) VALUES (?, ?)',
+    [feed_id, username]
+  );
+}
+
+async function getLikesByFeed(feedId) {
+  const [rows] = await pool.query(
+    'SELECT * FROM feed_likes WHERE feed_id = ? ORDER BY id ASC',
+    [feedId]
+  );
+  return rows;
+}
+
+module.exports = {
+  addLike,
+  getLikesByFeed,
+};

--- a/backend/routes/feedRoutes.js
+++ b/backend/routes/feedRoutes.js
@@ -4,5 +4,11 @@ const feedController = require('../controllers/feedController');
 
 router.get('/', feedController.getFeed);
 router.post('/', feedController.createFeed);
+router.post('/:id/like', feedController.likePost);
+router.get('/:id/likes', feedController.getLikes);
+router.post('/:id/fav', feedController.favPost);
+router.get('/:id/favs', feedController.getFavs);
+router.post('/:id/edit', feedController.editPost);
+router.delete('/:id', feedController.deletePost);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- enable likes, favs, edit and delete for feed posts
- store likes and favourites in dedicated models
- expose interaction endpoints through feedRoutes

## Testing
- `npm test --silent` in backend
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855dc594a608320bddbbf4ec2adb203