### PR TITLE
Fix comment routes

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -13,7 +13,7 @@ const projectRoutes = require('./routes/projectRoutes');
 const rankingRoutes = require('./routes/rankingRoutes');
 const retoRoutes = require('./routes/retoRoutes');
 const actividadRoutes = require('./routes/actividadRoutes');
-// const commentRoutes = require('./routes/commentRoutes'); // Descomenta si tienes esta ruta
+const commentRoutes = require('./routes/commentRoutes');
 
 const app = express();
 
@@ -42,7 +42,7 @@ app.use('/api/projects', projectRoutes);
 app.use('/api/ranking', rankingRoutes);
 app.use('/api/retos', retoRoutes);
 app.use('/api/actividad', actividadRoutes);
-// app.use('/api/comment', commentRoutes); // Descomenta si tienes esta ruta
+app.use('/api/comment', commentRoutes);
 
 // Ruta de salud para pruebas rápidas
 app.get('/api/health', (req, res) => {


### PR DESCRIPTION
## Summary
- expose comment routes by default

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855dc5849648320abca4adedd0af0f9