### PR TITLE
Fix multiple scroll listener

### DIFF
--- a/frontend/src/pages/Feed.jsx
+++ b/frontend/src/pages/Feed.jsx
@@ -167,7 +167,7 @@ const Feed = () => {
     };
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
-  });
+  }, []);
 
   const loadMoreFeed = async () => {
     setIsFetchingMore(true);


### PR DESCRIPTION
## Summary
- ensure `handleScroll` effect runs only once by adding empty dependency array

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix frontend run build` *(fails: `react-scripts: Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_6855dc59f1a08320ad06a5436ef0eb5f