### PR TITLE
Fix feed item keys and ensure id in API

### DIFF
--- a/backend/controllers/feedController.js
+++ b/backend/controllers/feedController.js
@@ -1,4 +1,5 @@
 const Feed = require('../models/Feed');
+const { randomUUID } = require('crypto');
 
 // GET /api/feed?page=1&perPage=10
 exports.getFeed = async (req, res) => {
@@ -6,11 +7,15 @@ exports.getFeed = async (req, res) => {
     let page = parseInt(req.query.page) || 1;
     let perPage = parseInt(req.query.perPage) || 10;
     const { rows, total } = await Feed.getFeedsPaginated(page, perPage);
+    const posts = rows.map((row) => ({
+      id: row.id || row.ID || randomUUID(),
+      ...row,
+    }));
     res.json({
       total,
       page,
       perPage,
-      posts: rows,
+      posts,
     });
   } catch (err) {
     console.error("ERROR EN GET FEED:", err);

--- a/frontend/src/pages/Feed.jsx
+++ b/frontend/src/pages/Feed.jsx
@@ -388,9 +388,9 @@ const Feed = () => {
               No hay publicaciones aún. ¡Sé el primero en compartir algo!
             </motion.div>
           )}
-          {filteredFeed.map((item, i) => (
+          {filteredFeed.map((item) => (
             <FeedItem
-              key={item.id || i}
+              key={item.id}
               item={item}
               dark={dark}
               usuario={usuario}


### PR DESCRIPTION
## Summary
- use `item.id` exclusively for react list keys
- guarantee posts returned from the API always include an `id`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855dc5b254c832097003f3a26a7e768