### PR TITLE
Add trending and user suggestion endpoints

### DIFF
--- a/backend/controllers/suggestedController.js
+++ b/backend/controllers/suggestedController.js
@@ -1,0 +1,19 @@
+const Suggested = require('../models/Suggested');
+
+exports.getSuggested = async (req, res) => {
+  try {
+    const users = await Suggested.getAllSuggested();
+    res.json(users);
+  } catch (e) {
+    res.status(500).json({ msg: 'Error al obtener sugerencias.' });
+  }
+};
+
+exports.createSuggested = async (req, res) => {
+  try {
+    const id = await Suggested.addSuggested(req.body);
+    res.json({ msg: 'Sugerencia creada', id });
+  } catch (e) {
+    res.status(500).json({ msg: 'Error al crear sugerencia.' });
+  }
+};

--- a/backend/controllers/trendingController.js
+++ b/backend/controllers/trendingController.js
@@ -1,0 +1,19 @@
+const Trending = require('../models/Trending');
+
+exports.getTrending = async (req, res) => {
+  try {
+    const tags = await Trending.getAllTrending();
+    res.json(tags);
+  } catch (e) {
+    res.status(500).json({ msg: 'Error al obtener tendencias.' });
+  }
+};
+
+exports.createTrending = async (req, res) => {
+  try {
+    const id = await Trending.addTrending(req.body);
+    res.json({ msg: 'Tendencia creada', id });
+  } catch (e) {
+    res.status(500).json({ msg: 'Error al crear tendencia.' });
+  }
+};

--- a/backend/models/Suggested.js
+++ b/backend/models/Suggested.js
@@ -1,0 +1,19 @@
+const pool = require('../config/db');
+
+async function getAllSuggested() {
+  const [rows] = await pool.query('SELECT * FROM suggested_users ORDER BY id DESC');
+  return rows;
+}
+
+async function addSuggested({ username, avatar }) {
+  const [result] = await pool.query(
+    'INSERT INTO suggested_users (username, avatar) VALUES (?, ?)',
+    [username, avatar]
+  );
+  return result.insertId;
+}
+
+module.exports = {
+  getAllSuggested,
+  addSuggested,
+};

--- a/backend/models/Trending.js
+++ b/backend/models/Trending.js
@@ -1,0 +1,19 @@
+const pool = require('../config/db');
+
+async function getAllTrending() {
+  const [rows] = await pool.query('SELECT * FROM trending ORDER BY count DESC');
+  return rows;
+}
+
+async function addTrending({ tag, count }) {
+  const [result] = await pool.query(
+    'INSERT INTO trending (tag, count) VALUES (?, ?)',
+    [tag, count]
+  );
+  return result.insertId;
+}
+
+module.exports = {
+  getAllTrending,
+  addTrending,
+};

--- a/backend/routes/suggestedRoutes.js
+++ b/backend/routes/suggestedRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const suggestedController = require('../controllers/suggestedController');
+
+router.get('/', suggestedController.getSuggested);
+
+module.exports = router;

--- a/backend/routes/trendingRoutes.js
+++ b/backend/routes/trendingRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const trendingController = require('../controllers/trendingController');
+
+router.get('/', trendingController.getTrending);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,6 +13,8 @@ const projectRoutes = require('./routes/projectRoutes');
 const rankingRoutes = require('./routes/rankingRoutes');
 const retoRoutes = require('./routes/retoRoutes');
 const actividadRoutes = require('./routes/actividadRoutes');
+const trendingRoutes = require('./routes/trendingRoutes');
+const suggestedRoutes = require('./routes/suggestedRoutes');
 // const commentRoutes = require('./routes/commentRoutes'); // Descomenta si tienes esta ruta
 
 const app = express();
@@ -42,6 +44,8 @@ app.use('/api/projects', projectRoutes);
 app.use('/api/ranking', rankingRoutes);
 app.use('/api/retos', retoRoutes);
 app.use('/api/actividad', actividadRoutes);
+app.use('/api/trending', trendingRoutes);
+app.use('/api/suggested', suggestedRoutes);
 // app.use('/api/comment', commentRoutes); // Descomenta si tienes esta ruta
 
 // Ruta de salud para pruebas rápidas

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -51,6 +51,8 @@ const Home = () => {
   const [feed, setFeed] = useState([]);
   const [actividad, setActividad] = useState([]);
   const [mensajes, setMensajes] = useState([]);
+  const [trending, setTrending] = useState([]);
+  const [suggested, setSuggested] = useState([]);
   const [progress, setProgress] = useState(0);
   const [xp, setXP] = useState(0);
   const [proyectosReal, setProyectosReal] = useState(0);
@@ -76,6 +78,8 @@ const Home = () => {
           feed,
           actividad,
           mensajes,
+          trendingData,
+          suggestedData,
         ] = await Promise.all([
           fetchData("/projects"),
           fetchData("/retos"),
@@ -84,6 +88,8 @@ const Home = () => {
           fetchData("/feed"),
           fetchData("/actividad"),
           fetchData("/messages"),
+          fetchData("/trending"),
+          fetchData("/suggested"),
         ]);
         if (cancel) return;
         setProjects(projects);
@@ -93,6 +99,8 @@ const Home = () => {
         setFeed(feed);
         setActividad(actividad);
         setMensajes(mensajes);
+        setTrending(trendingData);
+        setSuggested(suggestedData);
 
         // Estadísticas usuario (puedes personalizar)
         setProyectosReal(projects.length);
@@ -145,7 +153,7 @@ const Home = () => {
   );
 
   // Panel de sugerencias devs
-  const devsSugeridos = ranking.slice(0, 4);
+  const devsSugeridos = suggested.slice(0, 4);
 
   // Ranking con medallas
   const getMedal = (i) =>
@@ -280,6 +288,21 @@ const Home = () => {
               </a>
             ))}
           </div>
+        </div>
+      </Section>
+
+      {/* TRENDING TOPICS */}
+      <Section className="max-w-6xl mx-auto mt-2 mb-6">
+        <div className="flex items-center mb-2">
+          <h3 className={`text-lg font-bold ${dark ? "text-white" : "text-violet-700"}`}>Tendencias</h3>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {trending.map((t, i) => (
+            <span key={i} className="bg-violet-100 text-violet-800 px-3 py-1 rounded-xl text-sm">
+              #{t.tag}
+              <span className="ml-1 text-gray-500">{t.count}</span>
+            </span>
+          ))}
         </div>
       </Section>
 


### PR DESCRIPTION
## Summary
- add tables and controllers for trending and suggested features
- expose `/api/trending` and `/api/suggested` routes
- fetch trending data and suggestions in the home page
- display trending hashtags and suggested devs

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm --prefix backend test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855dc5dd6808320972f4eb5721c7bcd